### PR TITLE
Added DataFor(id) method to increase extensibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,19 +51,18 @@ module.exports = (opts) => {
 
         // add the peer
         const peerId = router.peerList.addPeer(req.query.peer_name, res)
-        const peerListStr = router.peerList.format()
 
         // send back the list of peers
         res.status(200)
             .set('Pragma', peerId)
             .set('Content-Type', 'text/plain')
-            .send(peerListStr)
+            .send(router.peerList.dataFor(peerId))
 
         // send an updated peer list to all peers
         router.peerList.getPeerIds().filter(id => id != peerId).forEach((id) => {
             // updated peer lists must always appear to come from
             // "ourselves", namely the srcId == destId
-            sendPeerMessage(id, id, peerListStr)
+            sendPeerMessage(id, id, router.peerList.dataFor(id))
         })
     })
 
@@ -123,14 +122,11 @@ module.exports = (opts) => {
         // remove the peer
         router.peerList.removePeer(req.query.peer_id)
 
-        // format the updated peerList
-        const peerListStr = router.peerList.format()
-
         // send an updated peer list to all peers
         router.peerList.getPeerIds().forEach((id) => {
             // updated peer lists must always appear to come from
             // "ourselves", namely the srcId == destId
-            sendPeerMessage(id, id, peerListStr)
+            sendPeerMessage(id, id, router.peerList.dataFor(id))
         })
 
         res.status(200).end()

--- a/lib/peer-list.js
+++ b/lib/peer-list.js
@@ -21,6 +21,7 @@ module.exports = class PeerList {
         if (this._peers[id]) {
             delete this._peers[id]
         }
+
     }
 
     getPeer(id) {
@@ -62,5 +63,11 @@ module.exports = class PeerList {
                 let e = this._peers[key]
                 return `${e.name},${e.id},${e.status() ? 1 : 0}`
             }).join('\n') + '\n'
+    }
+
+    dataFor(id) {
+        //returns the data that should appear for a given ID
+        //This is the primary part of peer-list that is extensible
+        return this.format()
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webrtc-signal-http",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -274,6 +274,20 @@ describe('webrtc-signal-http', () => {
 
             assert.equal(instance.format(), 'test2,2,0\ntest,1,0\n')
         })
+
+        it('should support formatting via dataFor() method', () => {
+            const instance = new PeerList()
+
+            instance.addPeer('test', { obj: true })
+
+            assert.equal(instance.dataFor('test'), 'test,1,0\n')
+
+            instance.addPeer('test2', { obj: true })
+
+            assert.equal(instance.dataFor('test2'), 'test2,2,0\ntest,1,0\n')
+        })
+
+
     })
 
     describe('Peer', () => {


### PR DESCRIPTION
The dataFor(id) method takes in a peer ID and returns only the data that the particular peer needs to see. This is a crucial change for increasing extensibility, and also doesn't cause any prior extensions to break.