### PR TITLE
fixing problems with event handler and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ To run locally run `npm run build` and `npm run start`
 To consume this server as a basis but add some extended functionality, `npm install webrtc-signal-http` and then run some code like the following:
 
 ```
-const express = require('express')
-const signalRouterCreator = require('webrtc-signal-http')
+import * as express from "express";
+import { signalRouterCreator } from "webrtc-signal-http";
 
 const app = express()
 const router = signalRouterCreator({

--- a/lib/peer-list.ts
+++ b/lib/peer-list.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 import Peer from "./peer";
-import { IPeerRequest, IPeerResponse, SignalEvent } from "./utils";
+import { IPeerRequest, IPeerResponse } from "./utils";
 
 export default class PeerList extends EventEmitter {
     private _peers: Peer[];

--- a/lib/peer-list.ts
+++ b/lib/peer-list.ts
@@ -14,31 +14,31 @@ export default class PeerList extends EventEmitter {
     }
 
     public addPeer(name: string, res: IPeerResponse, req: IPeerRequest) {
-        this.emit(SignalEvent.PrePeerAdd, name);
+        this.emit("addPeer:pre", name);
 
         const peer = new Peer(name, this._nextPeerId);
 
         peer.res = res;
         peer.ip = req.realIp || req.ip;
 
-        this.emit(SignalEvent.PeerAdd, peer);
+        this.emit("addPeer", peer);
         this._peers[peer.id] = peer;
         this._nextPeerId += 1;
 
-        this.emit(SignalEvent.PostPeerAdd, peer);
+        this.emit("addPeer:post", peer);
 
         return peer.id;
     }
 
     public removePeer(id: number) {
-        this.emit(SignalEvent.PrePeerRemove, id);
+        this.emit("removePeer:pre", id);
 
         if (this._peers[id]) {
             const cpy = this._peers[id];
-            this.emit(SignalEvent.PeerRemove, cpy);
+            this.emit("removePeer", cpy);
             delete this._peers[id];
 
-            this.emit(SignalEvent.PostPeerRemove, cpy);
+            this.emit("removePeer:post", cpy);
         }
 
     }

--- a/lib/peer-list.ts
+++ b/lib/peer-list.ts
@@ -3,9 +3,9 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import Peer from "./peer";
 import { IPeerRequest, IPeerResponse, ISignalerEvents } from "./utils";
 
-type MyEmitter = StrictEventEmitter<EventEmitter, ISignalerEvents>;
+type StrictSignalEmitter = StrictEventEmitter<EventEmitter, ISignalerEvents>;
 
-export default class PeerList extends (EventEmitter as new() => MyEmitter) {
+export default class PeerList extends (EventEmitter as new() => StrictSignalEmitter) {
     private _peers: Peer[];
     private _nextPeerId: number;
 

--- a/lib/peer-list.ts
+++ b/lib/peer-list.ts
@@ -1,8 +1,11 @@
 import { EventEmitter } from "events";
+import StrictEventEmitter from "strict-event-emitter-types";
 import Peer from "./peer";
-import { IPeerRequest, IPeerResponse } from "./utils";
+import { IPeerRequest, IPeerResponse, ISignalerEvents } from "./utils";
 
-export default class PeerList extends EventEmitter {
+type MyEmitter = StrictEventEmitter<EventEmitter, ISignalerEvents>;
+
+export default class PeerList extends (EventEmitter as new() => MyEmitter) {
     private _peers: Peer[];
     private _nextPeerId: number;
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from "express";
+import Peer from "./peer";
 import PeerList from "./peer-list";
 
 export interface IRouter extends Router {
@@ -23,6 +24,15 @@ export interface IPeerResponse extends Response {
 
 export interface IPeerRequest extends Request {
     realIp?: string;
+}
+
+export interface ISignalerEvents {
+    "addPeer:pre": string;
+    "addPeer": Peer;
+    "addPeer:post": Peer;
+    "removePeer:pre": number;
+    "removePeer": Peer;
+    "removePeer:post": Peer;
 }
 
 export function optIsFalsey(opt: string | boolean) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,15 +1,6 @@
 import { Request, Response, Router } from "express";
 import PeerList from "./peer-list";
 
-export enum SignalEvent {
-    PrePeerAdd = "addPeer:pre",
-    PeerAdd = "addPeer",
-    PostPeerAdd = "addPeer:post",
-    PrePeerRemove = "RemovePeer:pre",
-    PeerRemove = "RemovePeer",
-    PostPeerRemove = "RemovePeer:post",
-}
-
 export interface IRouter extends Router {
     peerList: PeerList;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webrtc-signal-http",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1072,6 +1072,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
     },
     "string_decoder": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "webrtc-signal-http-ts",
-  "version": "1.8.20",
+  "name": "webrtc-signal-http",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webrtc-signal-http",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "opinionated webrtc signal provider using http as a protocol",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
@@ -31,7 +31,8 @@
     "body-parser": "^1.18.2",
     "cors": "^2.8.4",
     "express": "^4.16.2",
-    "express-bunyan-logger": "^1.3.2"
+    "express-bunyan-logger": "^1.3.2",
+    "strict-event-emitter-types": "^2.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.4",

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -233,10 +233,10 @@ describe("webrtc-signal-http", () => {
             assert.equal(Object.keys(internalMap), 0);
         });
 
-        it("should emit SignalEvent.PrePeerAdd events", (done) => {
+        it("should emit addPeer:pre events", (done) => {
             const instance = new PeerList();
 
-            instance.once(SignalEvent.PrePeerAdd, (name) => {
+            instance.once("addPeer:pre", (name) => {
                 assert.ok(typeof name === "string");
                 done();
             });
@@ -244,10 +244,10 @@ describe("webrtc-signal-http", () => {
             const id = instance.addPeer("test", trueRes, emptyReq);
         });
 
-        it("should emit SignalEvent.PeerAdd events", (done) => {
+        it("should emit addPeer events", (done) => {
             const instance = new PeerList();
 
-            instance.once(SignalEvent.PeerAdd, (peer) => {
+            instance.once("addPeer", (peer) => {
                 assert.ok(peer instanceof Peer);
                 done();
             });
@@ -255,10 +255,10 @@ describe("webrtc-signal-http", () => {
             const id = instance.addPeer("test", trueRes, emptyReq);
         });
 
-        it("should emit SignalEvent.PostPeerAdd events", (done) => {
+        it("should emit addPeer:post events", (done) => {
             const instance = new PeerList();
 
-            instance.once(SignalEvent.PostPeerAdd, (peer) => {
+            instance.once("addPeer:post", (peer) => {
                 assert.ok(peer instanceof Peer);
                 done();
             });
@@ -266,10 +266,10 @@ describe("webrtc-signal-http", () => {
             const id = instance.addPeer("test", trueRes, emptyReq);
         });
 
-        it("should emit SignalEvent.PrePeerRemove events", (done) => {
+        it("should emit removePeer:pre events", (done) => {
             const instance = new PeerList();
 
-            instance.once(SignalEvent.PrePeerRemove, (id) => {
+            instance.once("removePeer:pre", (id) => {
                 assert.ok(typeof id === "number");
                 done();
             });
@@ -278,10 +278,10 @@ describe("webrtc-signal-http", () => {
             instance.removePeer(id);
         });
 
-        it("should emit SignalEvent.PeerRemove events", (done) => {
+        it("should emit removePeer events", (done) => {
             const instance = new PeerList();
 
-            instance.once(SignalEvent.PeerRemove, (peer) => {
+            instance.once("removePeer", (peer) => {
                 assert.ok(peer instanceof Peer);
                 done();
             });
@@ -290,10 +290,10 @@ describe("webrtc-signal-http", () => {
             instance.removePeer(id);
         });
 
-        it("should emit SignalEvent.PostPeerRemove events", (done) => {
+        it("should emit removePeer:post events", (done) => {
             const instance = new PeerList();
 
-            instance.once(SignalEvent.PostPeerRemove, (peer) => {
+            instance.once("removePeer:post", (peer) => {
                 assert.ok(peer instanceof Peer);
                 done();
             });


### PR DESCRIPTION
- the readme contained outdated instructions on importing webrtc-signal-http. (using require instead of importing the routercreator from the module)

- I had created and enum for signal event handling instead of the "peerAdd" "peerAdd:Post"... etc. Reverting back to the string version for compatibility with webrtc-signal-http-publisher

After merging, an update to the npm package will be required :) 